### PR TITLE
Require user-name and user-email

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -20,11 +20,9 @@ inputs:
         description: '[Optional] Tag to be released'
         required: false
     user-email:
-        description: '[Optional] Git User Email'
-        required: false
+        description: 'Git User Email'
     user-name:
-        description: '[Optional] Git User Name'
-        required: false
+        description: 'Git User Name'
 
 runs:
     using: 'docker'


### PR DESCRIPTION
I'm getting this error otherwise:
```
*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'root@18cae59d1c65.(none)')
```