### PR TITLE
Fix documentation for gitlab-ci.

### DIFF
--- a/docs/how_to_use_on_gitlab.md
+++ b/docs/how_to_use_on_gitlab.md
@@ -42,7 +42,7 @@ split_monorepo:
         USER_EMAIL: "info@kaizen-ci.org"
         REPOSITORY_HOST: "git.yourhost.com"
     script:
-        - echo "Splitting $PACKAGE_DIRECTORY to $SPLIT_REPOSITORY_NAME"
+        - echo "Splitting $PACKAGE_DIRECTORY to $REPOSITORY_NAME"
         - php /splitter/entrypoint.php
     when: always
 ```

--- a/docs/how_to_use_on_gitlab.md
+++ b/docs/how_to_use_on_gitlab.md
@@ -3,11 +3,9 @@
 GitHub Action is basically a yaml file that delegates parameters to a Docker run.
 We can use the same Docker image to split our repository in GitLab.
 
-```bash
-docker run symplify2/monorepo-split ... [args]
-```
-
 ## Configure `gitlab-ci.yml`
+
+You will need to [create personal access token](https://gitlab.com/-/profile/personal_access_tokens) and add the token to your Gitlab environment variable named `GITLAB_TOKEN`.
 
 All we need to do is configure input arguments:
 
@@ -17,7 +15,9 @@ stages:
 
 split_monorepo:
     stage: split
-
+    image:
+        name: symplify2/monorepo-split:latest
+        entrypoint: ["/usr/bin/env"]
     # see https://docs.gitlab.com/ee/ci/yaml/#parallel-matrix-jobs
     parallel:
         matrix:
@@ -33,18 +33,16 @@ split_monorepo:
     # see https://docs.gitlab.com/ee/ci/variables/#create-a-custom-cicd-variable-in-the-gitlab-ciyml-file
     variables:
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
-        PACKAGE_DIRETORY: $LOCAL_PATH
-        SPLIT_REPOSITORY_ORGANIZATION: "symplify"
-        SPLIT_REPOSITORY_NAME: $SPLIT_REPOSITORY
+        PACKAGE_DIRECTORY: $LOCAL_PATH
+        REPOSITORY_ORGANIZATION: "symplify"
+        REPOSITORY_NAME: $SPLIT_REPOSITORY
         BRANCH: "main"
-        TAG: null
+        TAG: ""
         USER_NAME: "kaizen-ci"
         USER_EMAIL: "info@kaizen-ci.org"
-        SPLIT_REPOSITORY_HOST: "git.yourhost.com"
-
+        REPOSITORY_HOST: "git.yourhost.com"
     script:
-        - echo "Splitting $PACKAGE_DIRETORY to $SPLIT_REPOSITORY_NAME"
-        - docker pull symplify2/monorepo-split:latest
-        - docker run symplify2/monorepo-split $PACKAGE_DIRECTORY $SPLIT_REPOSITORY_ORGANIZATION $SPLIT_REPOSITORY_NAME $BRANCH $TAG $USER_NAME $USER_EMAIL $SPLIT_REPOSITORY_HOST
+        - echo "Splitting $PACKAGE_DIRECTORY to $SPLIT_REPOSITORY_NAME"
+        - php /splitter/entrypoint.php
     when: always
 ```


### PR DESCRIPTION
The documentation method failed to pass the environment variables, so I tried a different method and was able to get it to work on gitlab-ci.　( on gitlab.com / gitlab-runner 13.12.0-rc1 )