### PR TITLE
Update the documentation according to the latest changes

### DIFF
--- a/.github/workflows/split.yaml
+++ b/.github/workflows/split.yaml
@@ -29,10 +29,10 @@ jobs:
                 env:
                     GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
                 with:
-                    package-directory: 'tests/packages/some-package'
-                    split-repository-organization: 'symplify'
-                    split-repository-name: 'monorepo-split-github-action-test'
+                    package_directory: 'tests/packages/some-package'
+                    repository_organization: 'symplify'
+                    repository_name: 'monorepo-split-github-action-test'
 
                     # change to use that should be signed under the split commit
-                    user-name: 'kaizen-ci'
-                    user-email: 'info@kaizen-ci.org'
+                    user_name: 'kaizen-ci'
+                    user_email: 'info@kaizen-ci.org'

--- a/README.md
+++ b/README.md
@@ -72,40 +72,40 @@ jobs:
             # no tag
             -
                 if: "!startsWith(github.ref, 'refs/tags/')"
-                uses: "symplify/monorepo-split-github-action@2.0"
+                uses: "symplify/monorepo-split-github-action@2.1"
                 with:
                     # ↓ split "packages/easy-coding-standard" directory
-                    package-directory: 'packages/${{ matrix.package.local_path }}'
+                    package_directory: 'packages/${{ matrix.package.local_path }}'
 
                     # ↓ into https://github.com/symplify/easy-coding-standard repository
-                    split-repository-organization: 'symplify'
-                    split-repository-name: '${{ matrix.package.split_repository }}'
+                    repository_organization: 'symplify'
+                    repository_name: '${{ matrix.package.split_repository }}'
 
                     # [optional, with "github.com" as default]
-                    split-repository-host: git.private.com:1234
+                    repository_host: git.private.com:1234
 
                     # ↓ the user signed under the split commit
-                    user-name: "kaizen-ci"
-                    user-email: "info@kaizen-ci.org"
+                    user_name: "kaizen-ci"
+                    user_email: "info@kaizen-ci.org"
 
             # with tag
             -
                 if: "startsWith(github.ref, 'refs/tags/')"
-                uses: "symplify/monorepo-split-github-action@2.0"
+                uses: "symplify/monorepo-split-github-action@2.1"
                 with:
                     tag: ${GITHUB_REF#refs/tags/}
 
                     # ↓ split "packages/easy-coding-standard" directory
-                    package-directory: 'packages/${{ matrix.package.local_path }}'
+                    package_directory: 'packages/${{ matrix.package.local_path }}'
 
                     # ↓ into https://github.com/symplify/easy-coding-standard repository
-                    split-repository-organization: 'symplify'
-                    split-repository-name: '${{ matrix.package.split_repository }}'
+                    repository_organization: 'symplify'
+                    repository_name: '${{ matrix.package.split_repository }}'
 
                     # [optional, with "github.com" as default]
-                    split-repository-host: git.private.com:1234
+                    repository_host: git.private.com:1234
 
                     # ↓ the user signed under the split commit
-                    user-name: "kaizen-ci"
-                    user-email: "info@kaizen-ci.org"
+                    user_name: "kaizen-ci"
+                    user_email: "info@kaizen-ci.org"
 ```


### PR DESCRIPTION
The current documentation is valid for the latest published version (`2.0`), but not for the `main` branch since #10. Hence, the purpose of this PR is to match the changes made to the `action.yaml` file.

I made an assumption for the next version number (`symplify/monorepo-split-github-action@2.1`), please let me know if you have another plan. 😉 