### PR TITLE
Fix mismatch between Git user name and email

### DIFF
--- a/src/ConfigFactory.php
+++ b/src/ConfigFactory.php
@@ -73,8 +73,8 @@ final class ConfigFactory
             // optional
             branch: $env[$envPrefix . 'BRANCH'] ?? null,
             tag: $env[$envPrefix . 'TAG'] ?? null,
-            userName: $env[$envPrefix . 'USER_EMAIL'] ?? null,
-            userEmail: $env[$envPrefix . 'USER_NAME'] ?? null,
+            userName: $env[$envPrefix . 'USER_NAME'] ?? null,
+            userEmail: $env[$envPrefix . 'USER_EMAIL'] ?? null,
             // required
             commitHash: $commitHash,
             accessToken: $accessToken


### PR DESCRIPTION
Hello, it's me again! 

Here is a small fix on the environment variables mapping. Fun fact... I did the same mismatch on my configuration, that's why I didn't see it earlier. 😅 