### PR TITLE
Fix for "Since using PHP, a `git push` error does not produce the run to fail"

### DIFF
--- a/entrypoint.php
+++ b/entrypoint.php
@@ -95,7 +95,7 @@ if ($changedFiles) {
     exec("git commit --message '$commitMessage'");
     exec('git push --quiet origin ' . $config->getBranch(), $outputLines, $exitCode);
     if ($exitCode > 0) {
-        die('Command failed');
+        die(sprintf('Command failed with exit code %s', $exitCode));
     }
 } else {
     note('No files to change');

--- a/entrypoint.php
+++ b/entrypoint.php
@@ -93,7 +93,10 @@ if ($changedFiles) {
     note($message);
 
     exec("git commit --message '$commitMessage'");
-    exec('git push --quiet origin ' . $config->getBranch());
+    $result = exec('git push --quiet origin ' . $config->getBranch());
+    if ($result === false) {
+        die('Command failed');
+    }
 } else {
     note('No files to change');
 }

--- a/entrypoint.php
+++ b/entrypoint.php
@@ -93,8 +93,8 @@ if ($changedFiles) {
     note($message);
 
     exec("git commit --message '$commitMessage'");
-    $result = exec('git push --quiet origin ' . $config->getBranch());
-    if ($result === false) {
+    exec('git push --quiet origin ' . $config->getBranch(), $outputLines, $exitCode);
+    if ($exitCode > 0) {
         die('Command failed');
     }
 } else {

--- a/entrypoint.php
+++ b/entrypoint.php
@@ -95,6 +95,7 @@ if ($changedFiles) {
     exec("git commit --message '$commitMessage'");
     exec('git push --quiet origin ' . $config->getBranch(), $outputLines, $exitCode);
     if ($exitCode > 0) {
+        exec('exit ' . $exitCode);
         die(sprintf('Command failed with exit code %s', $exitCode));
     }
 } else {


### PR DESCRIPTION
Fixes #17 

It is still not fully working, since #19 is happening. When that's fixed, this PR can change to Ready.