### PR TITLE
Added functionality for automagically creating upstream repositories and testing using dot env file

### DIFF
--- a/.github/workflows/split.yaml
+++ b/.github/workflows/split.yaml
@@ -30,9 +30,11 @@ jobs:
                     GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
                 with:
                     package_directory: 'tests/packages/some-package'
-                    repository_organization: 'symplify'
+                    repository_organization: 'hexxore'
                     repository_name: 'monorepo-split-github-action-test'
 
                     # change to use that should be signed under the split commit
-                    user_name: 'kaizen-ci'
-                    user_email: 'info@kaizen-ci.org'
+                    user_name: 'Wuffz'
+                    user_email: 'proozeboom91@gmail.com'
+
+                    init_new_repositories: true

--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,10 @@
     },
     "scripts": {
         "phpstan": "vendor/bin/phpstan analyse --ansi --error-format symplify"
+    },
+    "config": {
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        }
     }
 }

--- a/entrypoint.php
+++ b/entrypoint.php
@@ -23,6 +23,7 @@ setupGitCredentials($config);
 
 $cloneDirectory = sys_get_temp_dir() . '/monorepo_split/clone_directory';
 $buildDirectory = sys_get_temp_dir() . '/monorepo_split/build_directory';
+$dotGitDirectory = sys_get_temp_dir() . '/monorepo_split/clone_directory/.git';
 
 $hostRepositoryOrganizationName = $config->getGitRepository();
 
@@ -40,7 +41,7 @@ note('Cleaning destination repository of old files');
 mkdir($buildDirectory . '/.git', 0777, true);
 
 $copyGitDirectoryCommandLine = sprintf('cp -r %s %s', $cloneDirectory . '/.git', $buildDirectory);
-exec($copyGitDirectoryCommandLine, $outputLines, $exitCode);
+exec_with_note($copyGitDirectoryCommandLine, $outputLines, $exitCode);
 
 if ($exitCode === 1) {
     die('Command failed');
@@ -48,7 +49,7 @@ if ($exitCode === 1) {
 
 
 // cleanup old unused data to avoid pushing them
-exec('rm -rf ' . $cloneDirectory);
+exec_with_note('rm -rf ' . $cloneDirectory);
 // exec('rm -rf .git');
 
 
@@ -57,7 +58,15 @@ exec('rm -rf ' . $cloneDirectory);
 $copyMessage = sprintf('Copying contents to git repo of "%s" branch', $config->getCommitHash());
 note($copyMessage);
 $commandLine = sprintf('cp -ra %s %s', $config->getPackageDirectory() . '/.', $buildDirectory);
-exec($commandLine);
+exec_with_note($commandLine);
+
+
+// Do some checking if we should init the new repository here or not.
+// based on the remote origin within the current git tree we can determine if there is a repository present.
+
+note('This is a debugging test, to see wat the remote origin looks like from a runner point of view.')
+exec_with_output_print('git remote get-url origin');
+
 
 note('Files that will be pushed');
 list_directory_files($buildDirectory);

--- a/src/Config.php
+++ b/src/Config.php
@@ -18,7 +18,8 @@ final class Config
         private ?string $tag,
         private ?string $userName,
         private ?string $userEmail,
-        private string $accessToken
+        private string $accessToken,
+        private bool $initNewRepositories,
     ) {
     }
 
@@ -55,6 +56,10 @@ final class Config
     public function getAccessToken(): string
     {
         return $this->accessToken;
+    }
+    public function getInitNewRepository(): bool
+    {
+        return $this->initNewRepositories;
     }
 
     public function getGitRepository(): string

--- a/src/ConfigFactory.php
+++ b/src/ConfigFactory.php
@@ -75,6 +75,7 @@ final class ConfigFactory
             tag: $env[$envPrefix . 'TAG'] ?? null,
             userName: $env[$envPrefix . 'USER_NAME'] ?? null,
             userEmail: $env[$envPrefix . 'USER_EMAIL'] ?? null,
+            initNewRepositories: (bool)$env[$envPrefix . 'INIT_NEW_REPOSITORIES'] ?? false,
             // required
             commitHash: $commitHash,
             accessToken: $accessToken


### PR DESCRIPTION
# things i did:
- Added .env.example file for local testing.
- Added makefile for easy testing and extracting the local hash from current git repo to work on ( could also be done from within the container, but i just didn't )
- Added upstream repository creation ( specifically github, others not tested ) 
- Without any added parameters for this functionallity this work as before and not break any compatibility
- instead of die('command failed') i changed it to note and added exit(1) after that, that should make the action 'fail' within github. not succeed when it didn't succeed

## When creating a new github repository, the code will:
 - copy the project scope ( public/private ) from the main repository
 - generate the description for the new repository like this: [READ ONLY] Subtree split of the {ucfirst: mainrepo} packages (see {username or org}/{mainrepo})
 
I Tested this fork on my user account ( non org ) using .env and make:
https://github.com/wuffz/monorepo-split-github-action
https://github.com/wuffz/monorepo-split-github-action-test

I also field tested this on my new project within the organisation:
https://github.com/hexxore/supple < main repo
https://github.com/hexxore/quantum < child repo
https://github.com/hexxore/mirror < child repo