### PR TITLE
Upgrade to PHP 8.1

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -25,7 +25,7 @@ jobs:
             # see https://github.com/shivammathur/setup-php
             -   uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.0
+                    php-version: 8.1
                     coverage: none
 
             -   uses: "ramsey/composer-install@v1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # THIS IS BASE IMAGE
-FROM php:8.0-cli
+FROM php:8.1-cli
 
 RUN apt-get update -y
 RUN apt-get install git -y

--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,9 @@
         "phpstan/extension-installer": "^1.1"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12.85",
-        "symplify/phpstan-extensions": "^9.3",
-        "symplify/phpstan-rules": "^9.3"
+        "phpstan/phpstan": "^1.5",
+        "symplify/phpstan-extensions": "^10.2",
+        "symplify/phpstan-rules": "^10.2"
     },
     "autoload-dev": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,10 @@
     },
     "scripts": {
         "phpstan": "vendor/bin/phpstan analyse --ansi --error-format symplify"
+    },
+    "config": {
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "license": "MIT",
     "description": "GitHub Action for splitting monorepo. Composer is for testing PHP code only, not for package shipment",
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "phpstan/extension-installer": "^1.1"
     },
     "require-dev": {

--- a/src/Config.php
+++ b/src/Config.php
@@ -9,16 +9,16 @@ namespace Symplify\MonorepoSplit;
 final class Config
 {
     public function __construct(
-        private string $packageDirectory,
-        private string $repositoryHost,
-        private string $repositoryOrganization,
-        private string $repositoryName,
-        private string $commitHash,
-        private string $branch,
-        private ?string $tag,
-        private ?string $userName,
-        private ?string $userEmail,
-        private string $accessToken
+        private readonly string $packageDirectory,
+        private readonly string $repositoryHost,
+        private readonly string $repositoryOrganization,
+        private readonly string $repositoryName,
+        private readonly string $commitHash,
+        private readonly string $branch,
+        private readonly ?string $tag,
+        private readonly ?string $userName,
+        private readonly ?string $userEmail,
+        private readonly string $accessToken
     ) {
     }
 


### PR DESCRIPTION
This PR upgrades the entire package so that PHP `8.1` is used.
Other than being faster and coming with more features than `8.0`, `8.0` support will be finished by end November 2022.