### PR TITLE
Consistent use of git status --porcelain

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,10 @@
     },
     "scripts": {
         "phpstan": "vendor/bin/phpstan analyse --ansi --error-format symplify"
+    },
+    "config": {
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        }
     }
 }

--- a/entrypoint.php
+++ b/entrypoint.php
@@ -77,7 +77,7 @@ note($restoreChdirMessage);
 
 
 // avoids doing the git commit failing if there are no changes to be commit, see https://stackoverflow.com/a/8123841/1348344
-exec_with_output_print('git status');
+exec_with_output_print('git status --porcelain');
 
 // "status --porcelain" retrieves all modified files, no matter if they are newly created or not,
 // when "diff-index --quiet HEAD" only checks files that were already present in the project.


### PR DESCRIPTION
 I' ve run into problem, when monorepo split doesn`t work correctly if there are only new files without modification of any existing.

 I think, that problem will be with using `git status --porcelain` that provide empty output and because of that new files are not added to git.

 For start i suggest to ouput result of `git status --porcelain` so it is easier to debug where is problem.