### PR TITLE
Create branch while spliting if doesn't exist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,10 @@
     },
     "scripts": {
         "phpstan": "vendor/bin/phpstan analyse --ansi --error-format symplify"
+    },
+    "config": {
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        }
     }
 }

--- a/entrypoint.php
+++ b/entrypoint.php
@@ -79,6 +79,19 @@ note($restoreChdirMessage);
 // avoids doing the git commit failing if there are no changes to be commit, see https://stackoverflow.com/a/8123841/1348344
 exec_with_output_print('git status');
 
+// if the given branch doesn't exist it returns empty string
+$targetBranchExists = "" !== exec('git branch --list ' . $config->getBranch());
+
+if (!$targetBranchExists) {
+    note(sprintf('Creating branch "%s"', $config->getBranch()));
+
+    exec_with_output_print(sprintf('git checkout -b %s', $config->getBranch()));
+}
+
+note(sprintf('Switching to branch %s', $config->getBranch()));
+
+exec_with_output_print(sprintf('git checkout %s', $config->getBranch()));
+
 // "status --porcelain" retrieves all modified files, no matter if they are newly created or not,
 // when "diff-index --quiet HEAD" only checks files that were already present in the project.
 exec('git status --porcelain', $changedFiles);
@@ -87,6 +100,7 @@ exec('git status --porcelain', $changedFiles);
 
 if ($changedFiles) {
     note('Adding git commit');
+
     exec_with_output_print('git add .');
 
     $message = sprintf('Pushing git commit with "%s" message to "%s"', $commitMessage, $config->getBranch());


### PR DESCRIPTION
Hello 👋🏼!

While working on a monorepo supporting multiple versions (at the same time I want to be able to support `v1.x` and `v2.x`) I've noticed I have to create a new branch manually on every repo split from the monorepo.

And now... I'm coming up with the fix! When you want to split and push to the branch which doesn't exist on a split repository... the `monorepo-split-github-action` will create a new branch for you 🎉.

Case #1 Branch `8.x` doesn't exist on a split repo
![CleanShot 2022-09-08 at 12 13 14](https://user-images.githubusercontent.com/80641364/189097004-8d20b97e-f864-47c4-a527-468f17e9675e.png)

Case #2a Branch `8.x` is already existing there (and some changes appeared)
![CleanShot 2022-09-08 at 12 14 47](https://user-images.githubusercontent.com/80641364/189097264-58bf8cb5-4d94-43d4-859f-7b111d2c8823.png)

Case #2b same situation but there are some changes
![CleanShot 2022-09-08 at 12 13 50](https://user-images.githubusercontent.com/80641364/189097086-a06a337a-d0f1-4ef7-b698-4448b876fa26.png)
