### PR TITLE
Propose usage of alpine as a base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 # THIS IS BASE IMAGE
-FROM php:8.0-cli
+FROM php:8.1-cli-alpine
 
-RUN apt-get update -y
-RUN apt-get install git -y
+RUN apk add --no-cache git
 
 # directory inside docker
 WORKDIR /splitter


### PR DESCRIPTION
The reduced image size has a great impact on pipeline speed. Fewer data to download 😄

PS. Current debian-based docker build takes around 19 seconds.