### PR TITLE
change url to where to set secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ env:
     GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
 ```
 
-Make sure to add this access token in "Secrets" of package settings: `https://github.com/<organization>/<package>/settings/secrets/actions`
+Make sure to add this access token in "Secrets" of package settings at https://github.com/<organization>/<package>/settings/environments
 
 <br>
 


### PR DESCRIPTION
Setting the secret at the previous URL did not work for me, whereas setting it in an environment secret did.  However, I'm not at all sure that this is correct, so please review.  May fix https://github.com/symplify/symplify/issues/4428