### PR TITLE
Handle single quotes in commit messages

### DIFF
--- a/entrypoint.php
+++ b/entrypoint.php
@@ -114,7 +114,7 @@ if ($changedFiles) {
     $message = sprintf('Pushing git commit with "%s" message to "%s"', $commitMessage, $config->getBranch());
     note($message);
 
-    exec("git commit --message '{$commitMessage}'");
+    exec('git commit --message ' . escapeshellarg($commitMessage));
     exec('git push --quiet origin ' . $config->getBranch());
 } else {
     note('No files to change');


### PR DESCRIPTION
This PR fixes an issue where the monorepo splitting GitHub Action was failing when commit messages contained single quote characters (').

<img width="320" height="81" alt="image" src="https://github.com/user-attachments/assets/c819a09a-1bc3-4023-83c3-d2bea565b5c2" />
