### PR TITLE
Migrate Docker image from Docker Hub to GitHub Container Registry

### DIFF
--- a/.github/workflows/build_docker_images.yaml
+++ b/.github/workflows/build_docker_images.yaml
@@ -37,7 +37,7 @@ jobs:
                 with:
                     registry: ghcr.io
                     username: ${{ github.actor }}
-                    password: ${{ secrets.GITHUB_TOKEN }}
+                    password: ${{ secrets.ACCESS_TOKEN }}
 
             -
                 name: Build images

--- a/.github/workflows/build_docker_images.yaml
+++ b/.github/workflows/build_docker_images.yaml
@@ -18,26 +18,29 @@ jobs:
     publish_images:
         runs-on: ubuntu-20.04
 
+        permissions:
+            packages: write
+
         # see https://github.com/docker/build-push-action#git-context
         steps:
             -
                 name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v6
 
             -
                 name: Set up QEMU
-                uses: docker/setup-qemu-action@v1
+                uses: docker/setup-qemu-action@v3
 
             -
-                name: Login to DockerHub
-                uses: docker/login-action@v1
-                # create access token here https://hub.docker.com/settings/security
+                name: Login to GitHub Container Registry
+                uses: docker/login-action@v3
                 with:
-                    username: ${{ secrets.DOCKER_USERNAME }}
-                    password: ${{ secrets.DOCKER_PASSWORD }}
+                    registry: ghcr.io
+                    username: ${{ github.actor }}
+                    password: ${{ secrets.GITHUB_TOKEN }}
 
             -
                 name: Build images
                 run: |
-                    docker build . --tag symplify2/monorepo-split:latest --build-arg commitHash=${{ github.sha }}
-                    docker push symplify2/monorepo-split:latest
+                    docker build . --tag ghcr.io/${{ github.repository_owner }}/monorepo-split:latest --build-arg commitHash=${{ github.sha }}
+                    docker push ghcr.io/${{ github.repository_owner }}/monorepo-split:latest

--- a/.github/workflows/pull_docker_image.yaml
+++ b/.github/workflows/pull_docker_image.yaml
@@ -1,4 +1,4 @@
-# see .github/workflows/publish_docker_images.yaml:2
+# see .github/workflows/build_docker_images.yaml
 name: Pull Docker Image
 
 on:
@@ -10,11 +10,20 @@ on:
 jobs:
     pull_docker_image:
         runs-on: ubuntu-latest
+        permissions:
+            packages: read
 
         steps:
             -
+                name: 'Login to GitHub Container Registry'
+                uses: docker/login-action@v3
+                with:
+                    registry: ghcr.io
+                    username: ${{ github.actor }}
+                    password: ${{ secrets.GITHUB_TOKEN }}
+            -
                 name: 'Pull Docker image'
-                run: docker pull symplify2/monorepo-split:latest
+                run: docker pull ghcr.io/${{ github.repository_owner }}/monorepo-split:latest
             -
                 name: 'Run Docker image'
-                run: docker run symplify2/monorepo-split
+                run: docker run ghcr.io/${{ github.repository_owner }}/monorepo-split

--- a/.github/workflows/pull_docker_image.yaml
+++ b/.github/workflows/pull_docker_image.yaml
@@ -20,7 +20,7 @@ jobs:
                 with:
                     registry: ghcr.io
                     username: ${{ github.actor }}
-                    password: ${{ secrets.GITHUB_TOKEN }}
+                    password: ${{ secrets.ACCESS_TOKEN }}
             -
                 name: 'Pull Docker image'
                 run: docker pull ghcr.io/${{ github.repository_owner }}/monorepo-split:latest

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@
 
 Do you have [a monorepo](https://tomasvotruba.com/cluster/monorepo-from-zero-to-hero/) project on GitHub and need split packages to many repositories? Add this GitHub Action to your workflow and let it split your packages on every commit and tag.
 
+## Docker Image
+
+The Docker image is published to GitHub Container Registry (ghcr.io) and is available at:
+- `ghcr.io/danharrin/monorepo-split:latest` (latest main branch)
+- `ghcr.io/danharrin/monorepo-split:TAG` (specific tags)
+
+The image is automatically built and published on every push to the main branch and on every tag.
+
+> [!NOTE]
+> The image was previously hosted on Docker Hub as `symplify2/monorepo-split:latest`. It has been migrated to GitHub Container Registry for better integration with the project.
+
 ### How does the Split Result Look Like?
 
 This repository splits tests into [symplify/monorepo-split-github-action-test](https://github.com/symplify/monorepo-split-github-action-test) repository.

--- a/docs/how_to_use_on_gitlab.md
+++ b/docs/how_to_use_on_gitlab.md
@@ -16,7 +16,7 @@ stages:
 split_monorepo:
     stage: split
     image:
-        name: symplify2/monorepo-split:latest
+        name: ghcr.io/danharrin/monorepo-split:latest
         entrypoint: ["/usr/bin/env"]
     # see https://docs.gitlab.com/ee/ci/yaml/#parallel-matrix-jobs
     parallel:


### PR DESCRIPTION
Following the discussion in https://github.com/danharrin/monorepo-split-github-action/issues/58#issuecomment-3789821322, this PR proposes publishing the Docker image on GitHub Container Registry rather than Docker Hub following a change in project ownership.

The implementation guide, [Publishing a package using an action](https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#publishing-a-package-using-an-action) is more complex and uses additional packages. To facilitate migration, I only made the necessary changes based on the current version of the workflow.
I also updated the packages for the workflows I edited.