### PR TITLE
Escape Git user name in setupGitCredentials function

### DIFF
--- a/entrypoint.php
+++ b/entrypoint.php
@@ -195,7 +195,7 @@ function exec_with_output_print(string $commandLine): void
 function setupGitCredentials(Config $config): void
 {
     if ($config->getUserName()) {
-        execOrDie('git config --global user.name ' . $config->getUserName());
+        execOrDie('git config --global user.name ' . escapeshellarg($config->getUserName()));
     }
 
     if ($config->getUserEmail()) {


### PR DESCRIPTION
The `setupGitCredentials` method does not escape the user name.