### PR TITLE
fix(entrypoint): send error code 1 in catch

### DIFF
--- a/entrypoint.php
+++ b/entrypoint.php
@@ -15,7 +15,7 @@ try {
     $config = $configFactory->create(getenv());
 } catch (ConfigurationException $configurationException) {
     error($configurationException->getMessage());
-    exit(0);
+    exit(1);
 }
 
 exec('git config --system --add safe.directory /github/workspace');


### PR DESCRIPTION
I have GitlabCI and event when the command failed, i see that the error code is 0. We should change this to 1.



<img width="350" height="311" alt="image" src="https://github.com/user-attachments/assets/e7556652-9d6e-48f2-96e5-fc4cd49a933c" />
<img width="768" height="101" alt="image" src="https://github.com/user-attachments/assets/afe7a169-99e4-47f8-8f20-76ba83b90399" />
<img width="770" height="116" alt="image" src="https://github.com/user-attachments/assets/a0600a50-7c1f-4982-aa90-510aa1c716b0" />
